### PR TITLE
Added fastapi as optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ cryptography = "^3.1"
 
 [tool.poetry.extras]
 flask = ["flask"]
+fastapi = ["fastapi"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.2"


### PR DESCRIPTION
Hey, I added a small poetry change so FastAPI won't get installed every time, only when doing `pip install frontegg[fastapi]`. Feel free to either approve it or not. Thanks!