### PR TITLE
Fixed frontegg's requests blocking the FastAPI

### DIFF
--- a/frontegg/fastapi/frontegg.py
+++ b/frontegg/fastapi/frontegg.py
@@ -31,7 +31,7 @@ class Frontegg(FronteggProxy):
             methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
             include_in_schema=False,
         )
-        async def proxy_application(
+        async def proxy_frontegg_requests(
                 application_path: str,
                 request: Request,
         ) -> Response:

--- a/frontegg/fastapi/frontegg.py
+++ b/frontegg/fastapi/frontegg.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, Request, Response
 from frontegg.baseConfig.frontegg_proxy import FronteggProxy
 import typing
 import frontegg.fastapi.secure_access as secure_access
+from fastapi.concurrency import run_in_threadpool
+
 
 class Frontegg(FronteggProxy):
     def __init__(self):
@@ -24,19 +26,25 @@ class Frontegg(FronteggProxy):
 
         super(Frontegg, self).__init__(client_id, api_key, context_provider, authentication_middleware, middleware_prefix)
 
-        @app.middleware('http')
-        async def middleware(request: Request, call_next):
-            path = request.url.path
-            if path.startswith(self.middleware_prefix) or path.startswith('/'+self.middleware_prefix):
-                body = await request.body()
-                host = request.headers.get('host') or request.client.host
-                host = host.split(':')[0]
-                response = self.proxy_request(request=request, method=request.method, path=path,
-                                              host=host, body=body, headers=request.headers,
-                                              params=request.query_params)
-                return Response(content=response.content, status_code=response.status_code, headers=response.headers)
-            else:
-                response = await call_next(request)
-                return response
+        @app.api_route(
+            path="/" + self.middleware_prefix + "{application_path:path}",
+            methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+            include_in_schema=False,
+        )
+        async def proxy_application(
+                application_path: str,
+                request: Request,
+        ) -> Response:
+            body = await request.body()
+            host = request.headers.get('host') or request.client.host
+            host = host.split(':')[0]
+            response = await run_in_threadpool(
+                self.proxy_request,
+                request=request, method=request.method, path=application_path,
+                host=host, body=body, headers=request.headers,
+                params=request.query_params
+            )
+            return Response(content=response.content, status_code=response.status_code, headers=response.headers)
+
 
 frontegg = Frontegg()


### PR DESCRIPTION
Using the middleware as the proxy in FastAPI isn't the right way.
It causes the middleware to get blocked - which causes every frontegg request to wait for the response before other requests get in.

This is an ongoing issue with frontegg, and the right way to do proxies in FastAPI is to create an API route that does the proxying.

This branch fixes the issue, causing the UI to get ready (get all 4 frontegg requests) way quicker. From about 1.5 seconds on my laptop to 300-700ms (I'm in Israel tho)