### PR TITLE
chore(docs): Quick Typo fix in the title

### DIFF
--- a/frontegg/fastapi/README.md
+++ b/frontegg/fastapi/README.md
@@ -2,7 +2,7 @@
 <div align="center">
 <img src="https://fronteggstuff.blob.core.windows.net/frongegg-logos/logo-transparent.png" alt="Frontegg Logo" width="400" height="90">
 
-<h3 align="center">Frontegg Node.js Client</h3>
+<h3 align="center">Frontegg Python FastAPI Client</h3>
 
   <p align="center">
     Frontegg is a web platform where SaaS companies can set up their fully managed, scalable and brand aware - SaaS features and integrate them into their SaaS portals in up to 5 lines of code.


### PR DESCRIPTION
While reading through the doc, I noticed that the title says `Node.js` instead of `Python FastAPI`, suggesting a quick fix here 🙏🏼