### PR TITLE
Raise when getting an error

### DIFF
--- a/frontegg/common/clients/token_resolvers/access_token_services/services/tenant_access_token_service.py
+++ b/frontegg/common/clients/token_resolvers/access_token_services/services/tenant_access_token_service.py
@@ -23,6 +23,7 @@ class TenantAccessTokenService(AccessTokenService[ITenantAccessToken]):
     def get_active_access_token_ids_from_identity(self) -> List[str]:
         response = self.client.get(
             urljoin(frontegg_urls.identity_service['base_url'], 'resources/vendor-only/tenants/access-tokens/v1/active'))
+        response.raise_for_status()
         data = response.json()
 
         return data


### PR DESCRIPTION
When fetching active tokens, and the error description is a valid json (for example, if called without a proper token, `curl https://api.frontegg.com/audits/resources/vendor-only/tenants/access-tokens/v1/active` returns a valid json) then:
* `frontegg/common/clients/token_resolvers/access_token_services/services/tenant_access_token_service.py:get_active_access_token_ids_from_identity` return successfully the erroneous dict object
* `frontegg/common/clients/token_resolvers/access_token_services/services/access_token_service.py:get_active_access_token_ids` return successfully the erroneous dict object
* `frontegg/common/clients/token_resolvers/access_token_services/cache_services/cache_access_token_service.py:get_active_access_token_ids` stores a malformed object in cache! and returns it.
* `frontegg/common/clients/token_resolvers/access_token_resolver.py:__get_active_access_token_ids` return successfully the erroneous dict object
* `frontegg/common/clients/token_resolvers/access_token_resolver.py:validate_token` validates wether the token `sub` is in the error object, and obviously fails, failing the authentication process.